### PR TITLE
Fixes several issues

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,2 @@
-- Fix error when no doc is available, the error message is not shown, why?
 - When first try is for a word/WORD that does not have doc, then the
   syntax is not loaded correctly.

--- a/ftplugin/python_pydoc.vim
+++ b/ftplugin/python_pydoc.vim
@@ -172,13 +172,13 @@ endfunction
 
 " Mappings
 function s:PerformMappings()
-    nnoremap <silent> <buffer> <Leader>pw :silent call <SID>ShowPyDoc('<C-R><C-W>', 1)<CR>
-    nnoremap <silent> <buffer> <Leader>pW :silent call <SID>ShowPyDoc('<C-R><C-A>', 1)<CR>
-    nnoremap <silent> <buffer> <Leader>pk :silent call <SID>ShowPyDoc('<C-R><C-W>', 0)<CR>
-    nnoremap <silent> <buffer> <Leader>pK :silent call <SID>ShowPyDoc('<C-R><C-A>', 0)<CR>
+    nnoremap <silent> <buffer> <Leader>pw :call <SID>ShowPyDoc('<C-R><C-W>', 1)<CR>
+    nnoremap <silent> <buffer> <Leader>pW :call <SID>ShowPyDoc('<C-R><C-A>', 1)<CR>
+    nnoremap <silent> <buffer> <Leader>pk :call <SID>ShowPyDoc('<C-R><C-W>', 0)<CR>
+    nnoremap <silent> <buffer> <Leader>pK :call <SID>ShowPyDoc('<C-R><C-A>', 0)<CR>
 
     " remap the K (or 'help') key
-    nnoremap <silent> <buffer> K :silent call <SID>ShowPyDoc(expand("<cword>"), 1)<CR>
+    nnoremap <silent> <buffer> K :call <SID>ShowPyDoc(expand("<cword>"), 1)<CR>
 endfunction
 
 if g:pydoc_perform_mappings
@@ -186,5 +186,5 @@ if g:pydoc_perform_mappings
 endif
 
 " Commands
-command -nargs=1 Pydoc       :silent call s:ShowPyDoc('<args>', 1)
-command -nargs=* PydocSearch :silent call s:ShowPyDoc('<args>', 0)
+command -nargs=1 Pydoc       :call s:ShowPyDoc('<args>', 1)
+command -nargs=* PydocSearch :call s:ShowPyDoc('<args>', 0)


### PR DESCRIPTION
- Converts python_pydoc.vim to UTF-8
- Improves ftplugin behaviour:
  - No redefine function when executed several times the plugin
  - Global variables defined once on first time
- If the cursor is under a blank line, do not try to search for doc
- Set the `__doc__` buffer as nomodifiable
- Allows searches in the `__doc__` buffer with the correct syntax coloring
  using `filetype=python` and `syntax=man`
- Fixes highlighting and allow to highlight`WORD`
- Updates TODO with pending issues:
  - Fix error when no doc is available, the error message is not shown, why?
    (This is my fault, but I don't know how I broke it :-/)
  - When first try is for a `word/WORD` that does not have doc, then the
    syntax is not loaded correctly.
