### PR TITLE
ShowPyDoc not honoring g:pydoc_perform_mappings

### DIFF
--- a/ftplugin/python_pydoc.vim
+++ b/ftplugin/python_pydoc.vim
@@ -120,7 +120,9 @@ function s:ShowPyDoc(name, type)
             let l:pydoc_wh = -1
         else
             silent execute g:pydoc_open_cmd '__doc__'
-            call s:PerformMappings()
+            if g:pydoc_perform_mappings
+                call s:PerformMappings()
+            endif
         endif
     endif
 


### PR DESCRIPTION
This prevents `s:ShowPydoc` from calling `s:PerformMappings` if `g:pydoc_perform_mappings` is false. 
