### PR TITLE
Hide listchars in case they are globally enabled.

### DIFF
--- a/ftplugin/python_pydoc.vim
+++ b/ftplugin/python_pydoc.vim
@@ -147,6 +147,7 @@ function s:ShowPyDoc(name, type)
     setlocal buftype=nofile
     setlocal bufhidden=delete
     setlocal syntax=man
+    setlocal nolist
 
     silent normal ggdG
     " Remove function/method arguments


### PR DESCRIPTION
I just started using pydoc.vim and noticed that listchars are active in the **doc** buffer. The docs aren't all that tidy, so trailing whitespaces are all over the place. I suggest explicitely turning listchars off for the local buffer.
