### PR TITLE
Add lowercase command abbreviations

### DIFF
--- a/ftplugin/python_pydoc.vim
+++ b/ftplugin/python_pydoc.vim
@@ -246,3 +246,5 @@ endif
 " Commands
 command! -nargs=1 Pydoc       :call s:ShowPyDoc('<args>', 1)
 command! -nargs=* PydocSearch :call s:ShowPyDoc('<args>', 0)
+ca pyd Pydoc
+ca pyds PydocSearch


### PR DESCRIPTION
Lowercase command abbreviations allow for quicker use.
With this change, it is possible to type `:pyd<space>`
to bring up the view, or `pyds<space>` to search.
