### PR TITLE
 close easily with <esc> or enter

### DIFF
--- a/ftplugin/python_pydoc.vim
+++ b/ftplugin/python_pydoc.vim
@@ -210,6 +210,8 @@ function! s:ShowPyDoc(name, type)
     else
         setlocal nomodified
         setlocal nomodifiable
+        noremap <buffer> <silent> <CR> :<C-U>close<CR>
+        noremap <buffer> <silent> <Esc> :<C-U>close<CR>
     endif
 endfunction
 
@@ -274,3 +276,6 @@ command! -nargs=1 Pydoc       :call s:ShowPyDoc('<args>', 1)
 command! -nargs=* PydocSearch :call s:ShowPyDoc('<args>', 0)
 ca pyd Pydoc
 ca pyds PydocSearch
+
+
+


### PR DESCRIPTION
this change allows the doc buffer to be easily closed with pressing <esc> or <enter>